### PR TITLE
チャットルームの画面上部に相手（room）の名前を表示

### DIFF
--- a/lib/chat.dart
+++ b/lib/chat.dart
@@ -32,7 +32,7 @@ class _ChatPageState extends State<ChatPage> {
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
           systemOverlayStyle: SystemUiOverlayStyle.light,
-          title: const Text('Chat'),
+          title: Text(widget.room.name ?? 'Chat'),
         ),
         body: StreamBuilder<types.Room>(
           initialData: widget.room,


### PR DESCRIPTION
IDから名称取得はしていませんが、既に取得済の room から名称を取得しています。
現状roomの名称＝相手の名前になっているようです。
