### PR TITLE
画像読み込みエラー時のエラー処理追加

### DIFF
--- a/lib/edit_profile.dart
+++ b/lib/edit_profile.dart
@@ -101,6 +101,15 @@ class _EditProfilePageState extends State<EditProfilePage> {
                             backgroundImage: imageFile != null
                                 ? Image.file(imageFile!).image
                                 : NetworkImage(data['imageUrl']),
+                            onBackgroundImageError: (error, stackTrace) {
+                              assert(() {
+                                print('=' * 50);
+                                print(error.toString());
+                                print(stackTrace.toString());
+                                print('=' * 50);
+                                return true;
+                              }());
+                            },
                           ),
                         ),
                       ),

--- a/lib/my_page.dart
+++ b/lib/my_page.dart
@@ -128,6 +128,15 @@ class _BodyState extends State<_Body> {
                               width: 70,
                               child: CircleAvatar(
                                 backgroundImage: NetworkImage(data['imageUrl']),
+                                onBackgroundImageError: (error, stackTrace) {
+                                  assert(() {
+                                    print('=' * 50);
+                                    print(error.toString());
+                                    print(stackTrace.toString());
+                                    print('=' * 50);
+                                    return true;
+                                  }());
+                                },
                               ),
                             ),
                           ),

--- a/lib/rooms.dart
+++ b/lib/rooms.dart
@@ -125,6 +125,15 @@ class _RoomsPageState extends State<RoomsPage> {
       child: CircleAvatar(
         backgroundColor: hasImage ? Colors.transparent : color,
         backgroundImage: hasImage ? NetworkImage(room.imageUrl!) : null,
+        onBackgroundImageError: (error, stackTrace) {
+          assert(() {
+            print('=' * 50);
+            print(error.toString());
+            print(stackTrace.toString());
+            print('=' * 50);
+            return true;
+          }());
+        },
         radius: 20,
         child: !hasImage
             ? Text(
@@ -346,6 +355,15 @@ class _AppBarState extends State<_AppBar> {
                   padding: const EdgeInsets.all(10.0),
                   child: CircleAvatar(
                     backgroundImage: NetworkImage(data['imageUrl']),
+                    onBackgroundImageError: (error, stackTrace) {
+                      assert(() {
+                        print('=' * 50);
+                        print(error.toString());
+                        print(stackTrace.toString());
+                        print('=' * 50);
+                        return true;
+                      }());
+                    },
                   ),
                 );
               }

--- a/lib/users.dart
+++ b/lib/users.dart
@@ -78,6 +78,15 @@ class UsersPage extends StatelessWidget {
       child: CircleAvatar(
         backgroundColor: hasImage ? Colors.transparent : color,
         backgroundImage: hasImage ? NetworkImage(user.imageUrl!) : null,
+        onBackgroundImageError: (error, stackTrace) {
+          assert(() {
+            print('=' * 50);
+            print(error.toString());
+            print(stackTrace.toString());
+            print('=' * 50);
+            return true;
+          }());
+        },
         radius: 20,
         child: !hasImage
             ? Text(


### PR DESCRIPTION
デバッグ中は rethrow の箇所で停止することがあるようです。（継続可）
対応方法不明なため一旦そのままにしています。
